### PR TITLE
UI 조작 Gameplay Ability를 LocalOnly으로 변경

### DIFF
--- a/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_InGameMenu.cpp
+++ b/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_InGameMenu.cpp
@@ -2,27 +2,10 @@
 #include "Character/GRCharacter.h"
 #include "Player/Battle/GRBattlePlayerController.h"
 
-bool UGRGameplayAbility_InGameMenu::CanActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayTagContainer* SourceTags, const FGameplayTagContainer* TargetTags, OUT FGameplayTagContainer* OptionalRelevantTags) const
+UGRGameplayAbility_InGameMenu::UGRGameplayAbility_InGameMenu()
 {
-	if (!Super::CanActivateAbility(Handle, ActorInfo, SourceTags, TargetTags, OptionalRelevantTags))
-	{
-		return false;
-	}
-
-	AActor* AvatarActor = ActorInfo->AvatarActor.Get();
-	AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
-	if (!IsValid(GRCharacter))
-	{
-		return false;
-	}
-
-	AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
-	if (!IsValid(BattleController))
-	{
-		return false;
-	}
-
-	return true;
+	// UI 조작은 Local에서 처리할 수 있음
+	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::LocalOnly;
 }
 
 void UGRGameplayAbility_InGameMenu::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* OwnerInfo, const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData)
@@ -33,28 +16,21 @@ void UGRGameplayAbility_InGameMenu::ActivateAbility(const FGameplayAbilitySpecHa
 		return;
 	}
 
-	if (HasAuthority(&ActivationInfo))
-	{
-		AActor* AvatarActor = OwnerInfo->AvatarActor.Get();
-		AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
-		if (!IsValid(GRCharacter))
-		{
-			EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
-			return;
-		}
-
-		AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
-		if (!IsValid(BattleController))
-		{
-			EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
-			return;
-		}
-		BattleController->ClientRPC_ShowInGameMenuWidget();
-
-		EndAbility(Handle, OwnerInfo, ActivationInfo, true, false);
-	}
-	else
+	AActor* AvatarActor = OwnerInfo->AvatarActor.Get();
+	AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
+	if (!IsValid(GRCharacter))
 	{
 		EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
+		return;
 	}
+
+	AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
+	if (!IsValid(BattleController))
+	{
+		EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
+		return;
+	}
+
+	BattleController->ClientRPC_ShowInGameMenuWidget();
+	EndAbility(Handle, OwnerInfo, ActivationInfo, true, false);
 }

--- a/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_InGameMenu.h
+++ b/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_InGameMenu.h
@@ -9,14 +9,7 @@ class GUNROGUE_API UGRGameplayAbility_InGameMenu : public UGRGameplayAbility
 	GENERATED_BODY()
 	
 public:
-
-	virtual bool CanActivateAbility(
-		const FGameplayAbilitySpecHandle Handle,
-		const FGameplayAbilityActorInfo* ActorInfo,
-		const FGameplayTagContainer* SourceTags = nullptr,
-		const FGameplayTagContainer* TargetTags = nullptr,
-		OUT FGameplayTagContainer* OptionalRelevantTags = nullptr
-	) const override;
+	UGRGameplayAbility_InGameMenu();
 
 	virtual void ActivateAbility(
 		const FGameplayAbilitySpecHandle Handle,

--- a/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_ToggleInventory.cpp
+++ b/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_ToggleInventory.cpp
@@ -2,27 +2,10 @@
 #include "Character/GRCharacter.h"
 #include "Player/Battle/GRBattlePlayerController.h"
 
-bool UGRGameplayAbility_ToggleInventory::CanActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayTagContainer* SourceTags, const FGameplayTagContainer* TargetTags, OUT FGameplayTagContainer* OptionalRelevantTags) const
+UGRGameplayAbility_ToggleInventory::UGRGameplayAbility_ToggleInventory()
 {
-	if (!Super::CanActivateAbility(Handle, ActorInfo, SourceTags, TargetTags, OptionalRelevantTags))
-	{
-		return false;
-	}
-
-	AActor* AvatarActor = ActorInfo->AvatarActor.Get();
-	AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
-	if (!IsValid(GRCharacter))
-	{
-		return false;
-	}
-
-	AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
-	if (!IsValid(BattleController))
-	{
-		return false;
-	}
-
-	return true;
+	// UI 조작은 Local에서 처리할 수 있음
+	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::LocalOnly;
 }
 
 void UGRGameplayAbility_ToggleInventory::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* OwnerInfo, const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData)
@@ -33,28 +16,21 @@ void UGRGameplayAbility_ToggleInventory::ActivateAbility(const FGameplayAbilityS
 		return;
 	}
 
-	if (HasAuthority(&ActivationInfo))
-	{
-		AActor* AvatarActor = OwnerInfo->AvatarActor.Get();
-		AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
-		if (!IsValid(GRCharacter))
-		{
-			EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
-			return;
-		}
-
-		AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
-		if (!IsValid(BattleController))
-		{
-			EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
-			return;
-		}
-		BattleController->ClientRPC_ToggleInventoryWidget();
-
-		EndAbility(Handle, OwnerInfo, ActivationInfo, true, false);
-	}
-	else
+	AActor* AvatarActor = OwnerInfo->AvatarActor.Get();
+	AGRCharacter* GRCharacter = Cast<AGRCharacter>(AvatarActor);
+	if (!IsValid(GRCharacter))
 	{
 		EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
+		return;
 	}
+
+	AGRBattlePlayerController* BattleController = GRCharacter->GetController<AGRBattlePlayerController>();
+	if (!IsValid(BattleController))
+	{
+		EndAbility(Handle, OwnerInfo, ActivationInfo, true, true);
+		return;
+	}
+
+	BattleController->ClientRPC_ToggleInventoryWidget();
+	EndAbility(Handle, OwnerInfo, ActivationInfo, true, false);
 }

--- a/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_ToggleInventory.h
+++ b/Source/GunRogue/AbilitySystem/Abilities/GRGameplayAbility_ToggleInventory.h
@@ -9,14 +9,7 @@ class GUNROGUE_API UGRGameplayAbility_ToggleInventory : public UGRGameplayAbilit
 	GENERATED_BODY()
 	
 public:
-
-	virtual bool CanActivateAbility(
-		const FGameplayAbilitySpecHandle Handle,
-		const FGameplayAbilityActorInfo* ActorInfo,
-		const FGameplayTagContainer* SourceTags = nullptr,
-		const FGameplayTagContainer* TargetTags = nullptr,
-		OUT FGameplayTagContainer* OptionalRelevantTags = nullptr
-	) const override;
+	UGRGameplayAbility_ToggleInventory();
 
 	virtual void ActivateAbility(
 		const FGameplayAbilitySpecHandle Handle,


### PR DESCRIPTION

### Issue
- #217

### 변경 사항 요약
[1] 기존의 지식 오류 해결
'모든 Gameplay Ability가 서버에서 처리되어야 한다' 는 아닙니다.
클라이언트에서 할 수 있는 것은 클라이언트에서 처리 해도 괜찮습니다.
Inventory를 열거나 ESC 메뉴를 여는 동작은 굳이 서버에서 검증하지 않아도 됩니다.

[2] `NetExecutionPolicy` 변경
인벤토리를 여는 Ability와 ESC 메뉴를 여는 Ability의 동작 방법을 `LocalOnly`으로 변경했습니다.


### 테스트 방법
<!-- 구현한 내용을 어떻게 확인할 수 있는지, 어떻게 테스트할 수 있는지 설명하세요 -->
1. LobbyMap에서 테스트
2. 리슨 서버와 클라이언트에서 ESC 키, TAB 키를 눌러 어빌리티 발동



### 기타 사항
@prostruin 이정재님, 리뷰 부탁드립니다.

@khy1564 김효영님, 위의 내용 참고 바랍니다.  
저도 구현할 때는 생각 못했는데... ESC 메뉴나 인벤토리 Widget을 열 때 굳이 서버의 승인을 받을 필요가 없더라구요.

<!--
[Pull Reqeust 템플릿]
이 메시지는 '주석'이므로, 실제 문서에는 포함되지 않습니다.
PR을 제출하기 전, 아래 내용을 점검해주세요.

1. 올바른 리뷰어를 지정했는가?
3. 템플릿 안에 있는 불필요한 주석을 제거하고, 내용을 채웠는가? 
   템플릿 맨 위에 있는 주석과 맨 아래에 있는 지우지 않아도 됩니다.
-->

---
🙏 리뷰 감사합니다!
