### PR TITLE
증강 Wigdet을 띄울 때, 캐릭터가 계속 움직이는 문제를 해결함

### DIFF
--- a/Source/GunRogue/Player/Battle/GRBattlePlayerController_Augment.cpp
+++ b/Source/GunRogue/Player/Battle/GRBattlePlayerController_Augment.cpp
@@ -20,6 +20,7 @@ void AGRBattlePlayerController::ShowAugmentWidget()
 	}
 
 	FInputModeUIOnly Mode;
+	Mode.SetWidgetToFocus(AugmentWidgetInstance->GetCachedWidget());
 	SetInputMode(Mode);
 	bShowMouseCursor = true;
 }

--- a/Source/GunRogue/UI/Augment/GRAugmentHUDWidget.cpp
+++ b/Source/GunRogue/UI/Augment/GRAugmentHUDWidget.cpp
@@ -19,6 +19,8 @@ void UGRAugmentHUDWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
+	SetWidgetFocusable();
+
 	CreateAugmentSlot();
 
 	SetCharacterName();
@@ -245,4 +247,9 @@ void UGRAugmentHUDWidget::CreateAugmentSlot()
 		NewAugmentSlot->OnAugmentSlotHovered.AddDynamic(this, &UGRAugmentHUDWidget::ShowTooltip);
 		NewAugmentSlot->OnAugmentSlotUnhovered.AddDynamic(this, &UGRAugmentHUDWidget::HideTooltip);
 	}
+}
+
+void UGRAugmentHUDWidget::SetWidgetFocusable()
+{
+	SetIsFocusable(true);
 }

--- a/Source/GunRogue/UI/Augment/GRAugmentHUDWidget.h
+++ b/Source/GunRogue/UI/Augment/GRAugmentHUDWidget.h
@@ -50,5 +50,6 @@ public:
 	void HideTooltip(UGRAugmentSlotWidget* AugmentSlot);
 
 private:
+	void SetWidgetFocusable();
 	void CreateAugmentSlot();
 };


### PR DESCRIPTION
<!--
[Pull Reqeust 템플릿]
이 메시지는 '주석'이므로, 실제 문서에는 포함되지 않습니다.
PR을 작성하기 전, 아래 내용을 점검해주세요.

1. 문제없이 빌드가 되는 코드인가?
2. 내가 구현한 내용에 문제는 없는가?
3. Code Convention과 Unreal Project Convention을 잘 지켰는가?
4. branch의 이름을 올바르게 지었는가? (Unreal Project Convention 참고) 
-->

### Issue
<!-- 이슈를 연결해주세요 -->
<!-- 이슈 연결은 다음과 같이 작성해 주세요 -->
<!--
- #1
앞에 반드시 -를 붙이고, # 다음에 이슈 번호를 적어주세요
-->
- #297

### 변경 사항 요약
<!-- 이 PR에서 어떤 변경이 있었는지 요약해주세요 -->
- 다음 스테이지 선택 widget, 무기 강화 widget을 띄울 때는 캐릭터가 멈춤
- 증강 widget만 캐릭터가 계속 움직임
- 두 widget 구현의 차이를 확인하고, 증강 widget에 빠져있던 부분을 구현했습니다.
- 추가한 내용: focus 관련 부분


### 테스트 방법
<!-- 구현한 내용을 어떻게 확인할 수 있는지, 어떻게 테스트할 수 있는지 설명하세요 -->
1. Lobby에서 시작
2. `SetLevel1NextRoomBoss` 명령어 입력 
3. 게임 진행
4. w 키를 누른 상태에서 상호작용 키(F) 눌러 증강 widget을 띄우기
5. 캐릭터가 멈추는지 확인



### 스크린샷 (선택사항)

수정 후
https://github.com/user-attachments/assets/4a45a731-cd4b-4e46-a5ee-933d08970024


<!--
[Pull Reqeust 템플릿]
이 메시지는 '주석'이므로, 실제 문서에는 포함되지 않습니다.
PR을 제출하기 전, 아래 내용을 점검해주세요.

1. 올바른 리뷰어를 지정했는가?
6. 템플릿 안에 있는 불필요한 주석을 제거하고, 내용을 채웠는가? 
   템플릿 맨 위에 있는 주석과 맨 아래에 있는 지우지 않아도 됩니다.
-->

---
🙏 리뷰 감사합니다!
